### PR TITLE
🐛 Fix Pages deploy, refresh CI, add PR build-check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,16 @@
 # .github/workflows/deploy.yml
 # Build and deploy a VitePress site to GitHub Pages
-# Triggered on pushes to the main branch or "Run workflow" button
+# On pushes to main or a manual "Run workflow": build, then deploy to Pages
+# On pull requests targeting main: build only, as a check (no deploy)
 
 name: Deploy VitePress site to GitHub Pages
 
 on:
   workflow_dispatch: {} # Allow manual execution from the GitHub Actions tab
   push:
-    branches: [main] # Run this workflow only for commits to `main`
+    branches: [main] # Build and deploy on commits to `main`
+  pull_request:
+    branches: [main] # Build only (no deploy) to verify PRs targeting `main`
 
 permissions:
   contents: read
@@ -17,7 +20,8 @@ permissions:
 # Ensures that only one deploy runs at a time for this project
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  # Cancel a superseded PR build-check, but never cancel an in-progress deploy
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Build and upload job
@@ -60,11 +64,13 @@ jobs:
       - name: Build VitePress site
         run: pnpm build
 
-      # Step 7: Prepare artifact for GitHub Pages
+      # Step 7: Prepare and upload the Pages artifact (skipped on pull requests)
       - name: Setup GitHub Pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # actions/configure-pages@v6.0.0, pinned
 
       - name: Upload GitHub Pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # actions/upload-pages-artifact@v4.0.0, pinned
         with:
           path: contents/.vitepress/dist
@@ -72,6 +78,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
+    if: github.event_name != 'pull_request' # Deploy only for main pushes and manual runs
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Step 3: Install pnpm package manager (use detected version)
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pnpm/action-setup@v4.2.0, pinned
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # pnpm/action-setup@v6.0.8, pinned
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
 
@@ -62,12 +62,12 @@ jobs:
 
       # Step 7: Prepare artifact for GitHub Pages
       - name: Setup GitHub Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # actions/configure-pages@v5.0.0, pinned
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # actions/configure-pages@v6.0.0, pinned
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # actions/upload-pages-artifact@v4.0.0, pinned
         with:
-          path: .vitepress/dist
+          path: contents/.vitepress/dist
 
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/pr-lint-autofix.yml
+++ b/.github/workflows/pr-lint-autofix.yml
@@ -27,7 +27,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pnpm/action-setup@v4.2.0, pinned
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # pnpm/action-setup@v6.0.8, pinned
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
 

--- a/package.json
+++ b/package.json
@@ -46,12 +46,6 @@
   },
   "packageManager": "pnpm@11.11.0",
   "engines": {
-    "node": ">=20"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
+    "node": ">=24"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 allowBuilds:
-  esbuild: true
-  sharp: true
+  esbuild: false
+  sharp: false
 # Configure pnpm settings for the workspace
 
 # Delay installing published versions to reduce security risk.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 allowBuilds:
-  esbuild: false
-  sharp: false
+  esbuild: true
+  sharp: true
 # Configure pnpm settings for the workspace
 
 # Delay installing published versions to reduce security risk.


### PR DESCRIPTION
## Why

The **GitHub Pages deploy failed on every push from the June 11 `🚚 Restructure into contents/` commit onward** (last green: Feb 16), with:

```
tar: .vitepress/dist: Cannot open: No such file or directory
```

`pnpm build` runs `vitepress build contents`, so the site is emitted to `contents/.vitepress/dist`, but the workflow uploaded `.vitepress/dist`. Verified locally: after `pnpm build`, `contents/.vitepress/dist` exists and there is no root `.vitepress/dist`. Nothing caught this before merge, so this PR also adds a per-PR build check.

## What changed

**Deploy fix**

* Upload `contents/.vitepress/dist` in `deploy.yml` (the blocker).

**CI toolchain refresh**

* Bump `pnpm/action-setup` to v6.0.8 and `actions/configure-pages` to v6.0.0 (both SHA-pinned) in `deploy.yml` and `pr-lint-autofix.yml`.
* Raise `engines.node` to `>=24` and drop the redundant `devEngines.packageManager` block, which conflicted with `packageManager` and emitted a pnpm warning on every lint run.

**Per-PR build check**

* Add a `pull_request` trigger (targeting `main`) so every PR runs the build steps.
* Guard `configure-pages`, `upload-pages-artifact`, and the `deploy` job with `github.event_name != 'pull_request'` - PRs build but never deploy.
* `concurrency.cancel-in-progress` is now true only for `pull_request` events, so a superseded PR check is cancelled while an in-progress deploy is never interrupted.

## Provenance

The deploy fix and toolchain bumps were recovered from the abandoned scratch branch `temp` (never merged, 32 commits behind main), re-applied against current `main`, with two deliberate deviations to avoid regressions:

* `packageManager` kept at `pnpm@11.11.0` (temp would have downgraded to 11.5.3).
* No `.nvmrc` added; Node stays pinned via the existing `.node-version` (25.3.0), rather than adding a conflicting `.nvmrc=24`.

## Test

* `pnpm install --frozen-lockfile` + `pnpm build` succeed; output lands in `contents/.vitepress/dist`.
* `pnpm lint` clean, and the `packageManager`/`devEngines` warning is gone.
* `deploy.yml` validated as YAML.